### PR TITLE
Add option in daemonset for suricata listening interface

### DIFF
--- a/deploy/suricata-daemon/Dockerfile
+++ b/deploy/suricata-daemon/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-bullseye-slim
 
 RUN apt update
-RUN apt install suricata git -y
+RUN apt install suricata git iproute2 procps -y
 
 WORKDIR /app
 

--- a/deploy/suricata-daemon/entrypoint.sh
+++ b/deploy/suricata-daemon/entrypoint.sh
@@ -7,12 +7,21 @@ echo "STARTING"
 
 # INTERFACE=$(ip link | grep -w -P -o "eth.*(?=:)" | awk "NR==1{print $1}")
 # TODO : grep this from interfaces. Ignore part after @
-INTERFACE="eth0"
 
-sed -i "s/\${INTERFACE}/eth0/g" /etc/suricata/suricata.yaml
-
-echo "starting suricata"
-/usr/bin/suricata --pidfile /var/run/suricata.pid -c /etc/suricata/suricata.yaml -i $INTERFACE &
+if [[ -z "$METLO_LISTEN_INTERFACE" ]]; then
+    echo "Metlo interface NOT PROVIDED" 
+    echo "Defaulting to interface eth0"
+    sed -i "s/\${INTERFACE}/eth0/g" /etc/suricata/suricata.yaml
+    echo $INTERFACE
+    echo "starting suricata"
+    /usr/bin/suricata --pidfile /var/run/suricata.pid -c /etc/suricata/suricata.yaml -i eth0 &    
+else
+    echo "Metlo interface PROVIDED ${METLO_LISTEN_INTERFACE}"
+    sed -i "s/\${INTERFACE}/${INTERFACE}/g" /etc/suricata/suricata.yaml
+    echo $METLO_LISTEN_INTERFACE
+    echo "starting suricata"
+    /usr/bin/suricata --pidfile /var/run/suricata.pid -c /etc/suricata/suricata.yaml -i $METLO_LISTEN_INTERFACE &
+fi
 
 echo "starting metlo"
 node /etc/metlo-ingestor/ingestors/suricata/dist/index.js -s /tmp/eve.sock -u $METLO_ADDR -k $METLO_KEY &


### PR DESCRIPTION
Param can be provided as METLO_LISTEN_INTERFACE env param on docker/kubernetes. 
Defaults to eth0 if not provided