### PR TITLE
Set userSet var from UI

### DIFF
--- a/backend/src/api/endpoints/index.ts
+++ b/backend/src/api/endpoints/index.ts
@@ -190,6 +190,17 @@ export const updatePathsHandler = async (
   }
 }
 
+export const setUserSetHandler = async (req: MetloRequest, res: Response) => {
+  try {
+    const { endpointId } = req.params
+    const { userSetState } = req.body
+    await GetEndpointsService.setUserSet(req.ctx, endpointId, userSetState)
+    return await ApiResponseHandler.success(res)
+  } catch (err) {
+    await ApiResponseHandler.error(res, err)
+  }
+}
+
 export default function registerEndpointRoutes(router: Router) {
   router.get("/api/v1/endpoints/hosts", getHostsHandler)
   router.get("/api/v1/endpoints", getEndpointsHandler)
@@ -223,6 +234,7 @@ export default function registerEndpointRoutes(router: Router) {
   )
   router.post("/api/v1/clear-sensitive-data", clearAllSensitiveDataHandler)
   router.post("/api/v1/clear-all-datafields", bulkDeleteDataFieldsHandler)
+  router.post("/api/v1/endpoint/:endpointId/userSet", setUserSetHandler)
   // DataClass
   router.get("/api/v1/data-class", getDataClassInfo)
 }

--- a/backend/src/services/get-endpoints/index.ts
+++ b/backend/src/services/get-endpoints/index.ts
@@ -1,5 +1,5 @@
 import mlog from "logger"
-import { QueryRunner, UpdateResult } from "typeorm"
+import { Not, QueryRunner, UpdateResult } from "typeorm"
 import { AppDataSource } from "data-source"
 import {
   ApiEndpoint,
@@ -548,6 +548,23 @@ export class GetEndpointsService {
       return usage as UsageResponse[]
     } catch (err) {
       mlog.withErr(err).error("Error in Get Endpoints service")
+      throw new Error500InternalServer(err)
+    }
+  }
+
+  static async setUserSet(
+    ctx: MetloContext,
+    endpointId: string,
+    userSetState: boolean,
+  ) {
+    try {
+      await createQB(ctx)
+        .update(ApiEndpoint)
+        .andWhere({ uuid: endpointId })
+        .set({ userSet: userSetState })
+        .execute()
+    } catch (err) {
+      mlog.withErr(err).error("Error in Set UserSet endpoint")
       throw new Error500InternalServer(err)
     }
   }

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -200,6 +200,7 @@ export interface ApiEndpointDetailed extends ApiEndpoint {
   tests: any[]
   dataFields: DataField[]
   globalFullTraceCapture?: boolean
+  userSet: boolean
 }
 
 export interface HostResponse {

--- a/frontend/src/api/endpoints/index.ts
+++ b/frontend/src/api/endpoints/index.ts
@@ -180,3 +180,15 @@ export const updateFullTraceCaptureEnabled = async (
     { headers },
   )
 }
+
+export const setUserSetState = async (
+  endpointId: string,
+  userSet: boolean,
+  headers?: AxiosRequestHeaders,
+) => {
+  await axios.post(
+    `${getAPIURL()}/endpoint/${endpointId}/userSet`,
+    { userSetState: userSet },
+    { headers },
+  )
+}

--- a/frontend/src/components/Endpoint/Overview.tsx
+++ b/frontend/src/components/Endpoint/Overview.tsx
@@ -10,13 +10,14 @@ import {
   Checkbox,
   Tooltip,
   Switch,
+  useToast,
 } from "@chakra-ui/react"
 import dynamic from "next/dynamic"
 import { DataAttribute, DataHeading } from "components/utils/Card"
 import EndpointUsageChart from "./UsageChart"
 import { RISK_TO_COLOR } from "~/constants"
 import EndpointPIIChart from "./PIIChart"
-import { getDateTimeString } from "utils"
+import { getDateTimeString, makeToast } from "utils"
 import { DataTag, Status } from "@common/enums"
 import { setUserSetState, updateEndpointAuthenticated } from "api/endpoints"
 import { QuestionOutlineIcon } from "@chakra-ui/icons"
@@ -30,6 +31,7 @@ interface EndpointOverviewProps {
 
 const EndpointOverview: React.FC<EndpointOverviewProps> = React.memo(
   ({ endpoint, usage }) => {
+    const toast = useToast()
     const [userSet, setUserSet] = useState<boolean>(endpoint.userSet ?? false)
     const [settingUserSet, updateUserSetLoading] = useState<boolean>(false)
     const piiFields = endpoint.dataFields.filter(
@@ -58,7 +60,7 @@ const EndpointOverview: React.FC<EndpointOverviewProps> = React.memo(
         toast(
           makeToast(
             {
-              title: "Could not change userSet state...",
+              title: "Could not change endpoint validated state...",
               status: "error",
               description: err.response?.data,
             },
@@ -138,18 +140,12 @@ const EndpointOverview: React.FC<EndpointOverviewProps> = React.memo(
               </HStack>
             </GridItem>
             <GridItem>
-              <HStack>
-                <Box>
-                  <DataHeading>Verfied by User</DataHeading>
-                </Box>
-                <Box>
-                  <Tooltip
-                    label={`Is the endpoint verified? (Currently: ${userSet})`}
-                  >
-                    <QuestionOutlineIcon boxSize={"3"} />
-                  </Tooltip>
-                </Box>
-              </HStack>
+              <Tooltip label="Set this endpoint as validated.">
+                <HStack alignItems="center" pb="1">
+                  <DataHeading pb="0">Endpoint Validated</DataHeading>
+                  <QuestionOutlineIcon boxSize={"3"} />
+                </HStack>
+              </Tooltip>
               <Switch
                 isChecked={userSet}
                 onChange={handleUserSet}
@@ -181,13 +177,3 @@ const EndpointOverview: React.FC<EndpointOverviewProps> = React.memo(
 )
 
 export default EndpointOverview
-function toast(arg0: any) {
-  throw new Error("Function not implemented.")
-}
-
-function makeToast(
-  arg0: { title: string; status: string; description: any },
-  status: any,
-): any {
-  throw new Error("Function not implemented.")
-}

--- a/frontend/src/components/Endpoint/Overview.tsx
+++ b/frontend/src/components/Endpoint/Overview.tsx
@@ -140,7 +140,7 @@ const EndpointOverview: React.FC<EndpointOverviewProps> = React.memo(
               </HStack>
             </GridItem>
             <GridItem>
-              <Tooltip label="Set this endpoint as validated.">
+              <Tooltip label="Set this endpoint as user validated.">
                 <HStack alignItems="center" pb="1">
                   <DataHeading pb="0">Endpoint Validated</DataHeading>
                   <QuestionOutlineIcon boxSize={"3"} />

--- a/frontend/src/components/Endpoint/index.tsx
+++ b/frontend/src/components/Endpoint/index.tsx
@@ -70,8 +70,6 @@ const EndpointPage: React.FC<EndpointPageProps> = React.memo(
       "rgb(179, 181, 185)",
       "rgb(91, 94, 109)",
     )
-    const [userSet, setUserSet] = useState<boolean>(endpoint.userSet ?? false)
-    const [settingUserSet, updateUserSetLoading] = useState<boolean>(false)
     const [deleting, setDeleting] = useState<boolean>(false)
     const { isOpen, onOpen, onClose } = useDisclosure()
     const cancelRef = React.useRef()
@@ -123,27 +121,6 @@ const EndpointPage: React.FC<EndpointPageProps> = React.memo(
         routerParams["query"] = { tab: newTab }
       }
       router.push(routerParams, undefined, { shallow: true })
-    }
-
-    const handleUserSet = async () => {
-      updateUserSetLoading(true)
-      try {
-        await setUserSetState(endpoint.uuid, !userSet)
-        setUserSet(!userSet)
-      } catch (err) {
-        toast(
-          makeToast(
-            {
-              title: "Could not change userSet state...",
-              status: "error",
-              description: err.response?.data,
-            },
-            err.response?.status,
-          ),
-        )
-      } finally {
-        updateUserSetLoading(false)
-      }
     }
 
     return (
@@ -200,18 +177,6 @@ const EndpointPage: React.FC<EndpointPageProps> = React.memo(
               </Code>
             </Stack>
             <HStack alignSelf="flex-start">
-              <Tooltip
-                label={`Is the endpoint verified? (Currently: ${userSet})`}
-              >
-                <Button
-                  variant={userSet ? "solid" : "outline"}
-                  colorScheme="blue"
-                  onClick={handleUserSet}
-                  isLoading={settingUserSet}
-                >
-                  User Set
-                </Button>
-              </Tooltip>
               <EditPath
                 endpointPath={endpoint.path}
                 endpointId={endpoint.uuid}


### PR DESCRIPTION
Looks like this: ![Screenshot 2023-02-21 at 11 53 14 PM](https://user-images.githubusercontent.com/32181677/220428402-3acfd85e-d4b7-4975-beb6-adb04bf9b2c7.png)

Didn't go with the button since that just looked cryptic in what it was supposed to do and it was hard to tell that it was a toggle, despite switching from outline to solid button style. The switch is clean and clear, but didn't fit with the other buttons, so moved to overview. IMO makes more sense there anyways, along with the endpoint `Authenticated` checkbox(es)