### PR TITLE
Add public/private hosts listing on hosts page

### DIFF
--- a/backend/src/analyze-traces.ts
+++ b/backend/src/analyze-traces.ts
@@ -17,7 +17,6 @@ import { isGraphQlEndpoint } from "services/graphql"
 import { isQueryFailedError, retryTypeormTransaction } from "utils/db"
 import { MetloContext } from "types"
 import {
-  createQB,
   getEntityManager,
   insertValueBuilder,
   insertValuesBuilder,
@@ -164,6 +163,12 @@ const generateEndpoint = async (
     newEndpoint?: boolean,
   ) => Promise<void>,
 ): Promise<void> => {
+  await insertValueBuilder(ctx, queryRunner, Hosts, {
+    host: trace.host,
+    isPublic: false,
+  })
+    .orIgnore()
+    .execute()
   const isGraphQl = isGraphQlEndpoint(trace.path)
   let paramNum = 1
   let parameterizedPath = ""
@@ -172,12 +177,6 @@ const generateEndpoint = async (
     parameterizedPath = trace.path
     pathRegex = trace.path
   } else {
-    await createQB(ctx)
-      .insert()
-      .into(Hosts)
-      .values({ host: trace.host, isPublic: false })
-      .orIgnore()
-      .execute()
     const pathTokens = getPathTokens(trace.path)
     for (let j = 0; j < pathTokens.length; j++) {
       const tokenString = pathTokens[j]

--- a/backend/src/analyze-traces.ts
+++ b/backend/src/analyze-traces.ts
@@ -1,7 +1,7 @@
 import mlog from "logger"
 import { v4 as uuidv4 } from "uuid"
 import { AppDataSource } from "data-source"
-import { ApiEndpoint, DataField } from "models"
+import { ApiEndpoint, DataField, Hosts } from "models"
 import { RedisClient } from "utils/redis"
 import { TRACES_QUEUE } from "~/constants"
 import { QueryRunner, Raw } from "typeorm"
@@ -17,6 +17,7 @@ import { isGraphQlEndpoint } from "services/graphql"
 import { isQueryFailedError, retryTypeormTransaction } from "utils/db"
 import { MetloContext } from "types"
 import {
+  createQB,
   getEntityManager,
   insertValueBuilder,
   insertValuesBuilder,
@@ -171,6 +172,12 @@ const generateEndpoint = async (
     parameterizedPath = trace.path
     pathRegex = trace.path
   } else {
+    await createQB(ctx)
+      .insert()
+      .into(Hosts)
+      .values({ host: trace.host, isPublic: false })
+      .orIgnore()
+      .execute()
     const pathTokens = getPathTokens(trace.path)
     for (let j = 0; j < pathTokens.length; j++) {
       const tokenString = pathTokens[j]

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -41,3 +41,4 @@ export const TRACES_QUEUE = "traces_queue"
 
 export const TRACE_IN_MEM_RETENTION_COUNT = 100
 export const TRACE_IN_MEM_EXPIRE_SEC = 60 * 60 * 24 * 7
+export const HOST_TEST_CHUNK_SIZE = 10

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -17,6 +17,7 @@ import {
   Attack,
   Webhook,
   TestingConfig,
+  Hosts,
 } from "models"
 import { runMigration } from "utils"
 import { initMigration1665782029662 } from "migrations/1665782029662-init-migration"
@@ -44,6 +45,7 @@ import { addHostAndMethodIndex1676006521189 } from "migrations/1676006521189-add
 import { addFullTraceCaptureEnabledColumn1676065168441 } from "migrations/1676065168441-addFullTraceCaptureEnabledColumn"
 import { addOriginalHostTraceColumn1676358211583 } from "migrations/1676358211583-addOriginalHostTraceColumn"
 import { addTestingConfigTable1676508983994 } from "migrations/1676508983994-add-testing-config-table"
+import { hostsList1677073188312 } from "migrations/1677073188312-hosts_list"
 
 export const AppDataSource: DataSource = new DataSource({
   type: "postgres",
@@ -66,6 +68,7 @@ export const AppDataSource: DataSource = new DataSource({
     MetloConfig,
     Webhook,
     TestingConfig,
+    Hosts
   ],
   synchronize: false,
   migrations: [
@@ -93,6 +96,7 @@ export const AppDataSource: DataSource = new DataSource({
     addFullTraceCaptureEnabledColumn1676065168441,
     addOriginalHostTraceColumn1676358211583,
     addTestingConfigTable1676508983994,
+    hostsList1677073188312,
   ],
   migrationsRun: runMigration,
   logging: false,

--- a/backend/src/jobs.ts
+++ b/backend/src/jobs.ts
@@ -162,7 +162,7 @@ const main = async () => {
     )
   })
 
-  schedule.scheduleJob("0 */6 * * *", async () => {
+  schedule.scheduleJob("0 */1 * * *", async () => {
     await detectPrivateIPQueue.add(
       `${JobName.DETECT_PRIVATE_HOSTS}`,
       {},

--- a/backend/src/jobs.ts
+++ b/backend/src/jobs.ts
@@ -80,6 +80,7 @@ const main = async () => {
   const logAggregatedStatsQueue = createQueue(JobName.LOG_AGGREGATED_STATS)
   const fixEndpointsQueue = createQueue(JobName.FIX_ENDPOINTS)
   const detectSensitiveDataQueue = createQueue(JobName.DETECT_SENSITIVE_DATA)
+  const detectPrivateIPQueue = createQueue(JobName.DETECT_PRIVATE_IP)
 
   const queues: QueueInterface[] = [
     specQueue,
@@ -90,6 +91,7 @@ const main = async () => {
     logAggregatedStatsQueue,
     fixEndpointsQueue,
     detectSensitiveDataQueue,
+    detectPrivateIPQueue,
   ]
 
   schedule.scheduleJob("*/60 * * * *", async () => {
@@ -157,6 +159,14 @@ const main = async () => {
       `${JobName.DETECT_SENSITIVE_DATA}`,
       {},
       { ...defaultJobOptions, jobId: JobName.DETECT_SENSITIVE_DATA },
+    )
+  })
+
+  schedule.scheduleJob("*/30 * * * *", async () => {
+    await detectPrivateIPQueue.add(
+      `${JobName.DETECT_PRIVATE_IP}`,
+      {},
+      { ...defaultJobOptions, jobId: JobName.DETECT_PRIVATE_IP },
     )
   })
 

--- a/backend/src/jobs.ts
+++ b/backend/src/jobs.ts
@@ -80,7 +80,7 @@ const main = async () => {
   const logAggregatedStatsQueue = createQueue(JobName.LOG_AGGREGATED_STATS)
   const fixEndpointsQueue = createQueue(JobName.FIX_ENDPOINTS)
   const detectSensitiveDataQueue = createQueue(JobName.DETECT_SENSITIVE_DATA)
-  const detectPrivateIPQueue = createQueue(JobName.DETECT_PRIVATE_IP)
+  const detectPrivateIPQueue = createQueue(JobName.DETECT_PRIVATE_HOSTS)
 
   const queues: QueueInterface[] = [
     specQueue,
@@ -164,9 +164,9 @@ const main = async () => {
 
   schedule.scheduleJob("*/5 * * * *", async () => {
     await detectPrivateIPQueue.add(
-      `${JobName.DETECT_PRIVATE_IP}`,
+      `${JobName.DETECT_PRIVATE_HOSTS}`,
       {},
-      { ...defaultJobOptions, jobId: JobName.DETECT_PRIVATE_IP },
+      { ...defaultJobOptions, jobId: JobName.DETECT_PRIVATE_HOSTS },
     )
   })
 

--- a/backend/src/jobs.ts
+++ b/backend/src/jobs.ts
@@ -162,7 +162,7 @@ const main = async () => {
     )
   })
 
-  schedule.scheduleJob("*/5 * * * *", async () => {
+  schedule.scheduleJob("0 */6 * * *", async () => {
     await detectPrivateIPQueue.add(
       `${JobName.DETECT_PRIVATE_HOSTS}`,
       {},

--- a/backend/src/jobs.ts
+++ b/backend/src/jobs.ts
@@ -162,7 +162,7 @@ const main = async () => {
     )
   })
 
-  schedule.scheduleJob("*/30 * * * *", async () => {
+  schedule.scheduleJob("*/5 * * * *", async () => {
     await detectPrivateIPQueue.add(
       `${JobName.DETECT_PRIVATE_IP}`,
       {},

--- a/backend/src/migrations/1677073188312-hosts_list.ts
+++ b/backend/src/migrations/1677073188312-hosts_list.ts
@@ -1,0 +1,44 @@
+import axios from "axios"
+import { ApiEndpoint, Hosts } from "models"
+import { getEntityManager, getQB } from "services/database/utils"
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class hostsList1677073188312 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "hosts" ("uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "host" text NOT NULL,"isPublic" bool DEFAULT false, CONSTRAINT "PK_hosts" PRIMARY KEY ("uuid"))`,
+    )
+    // TODO: Get organization here
+    await Promise.all(
+      (
+        await getQB({}, queryRunner)
+          .select(["host"])
+          .from(ApiEndpoint, "endpoint")
+          .distinct(true)
+          .groupBy("host")
+          .getRawMany()
+      ).map(async ({ host }) => {
+        let isPublic = false
+        try {
+          const resp = await axios.get(`http://${host}`)
+          if (resp && resp.status) {
+            isPublic = true
+          }
+        } catch (err) {
+          // pass
+        }
+        try {
+          const res = await getEntityManager({}, queryRunner).insert(Hosts, [
+            { host, isPublic },
+          ])
+        } catch (err) {
+          // pass
+        }
+      }),
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "hosts"`)
+  }
+}

--- a/backend/src/migrations/1677073188312-hosts_list.ts
+++ b/backend/src/migrations/1677073188312-hosts_list.ts
@@ -2,13 +2,21 @@ import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class hostsList1677073188312 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // TODO: Add org to unique in enterprise migration
     await queryRunner.query(
-      `CREATE TABLE IF NOT EXISTS "hosts" ("uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "host" text NOT NULL,"isPublic" bool DEFAULT false, CONSTRAINT "PK_hosts" PRIMARY KEY ("uuid"), CONSTRAINT "unique_host_per_org" UNIQUE ("host"))`,
+      `CREATE TABLE IF NOT EXISTS "hosts" (
+        "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "host" text NOT NULL,
+        "isPublic" bool DEFAULT false,
+        CONSTRAINT "PK_hosts" PRIMARY KEY ("uuid"), CONSTRAINT "unique_host_per_org" UNIQUE ("host")
+      )`,
+    )
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "hosts_table_host_name_idx" ON "hosts" ("host")`,
     )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP TABLE IF EXISTS "hosts"`)
+    await queryRunner.query(`DROP INDEX IF EXISTS "hosts_table_host_name_idx"`)
   }
 }

--- a/backend/src/migrations/1677073188312-hosts_list.ts
+++ b/backend/src/migrations/1677073188312-hosts_list.ts
@@ -1,40 +1,10 @@
-import axios from "axios"
-import { ApiEndpoint, Hosts } from "models"
-import { getEntityManager, getQB } from "services/database/utils"
 import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class hostsList1677073188312 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // TODO: Add org to unique in enterprise migration
     await queryRunner.query(
-      `CREATE TABLE IF NOT EXISTS "hosts" ("uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "host" text NOT NULL,"isPublic" bool DEFAULT false, CONSTRAINT "PK_hosts" PRIMARY KEY ("uuid"))`,
-    )
-    // TODO: Get organization here
-    await Promise.all(
-      (
-        await getQB({}, queryRunner)
-          .select(["host"])
-          .from(ApiEndpoint, "endpoint")
-          .distinct(true)
-          .groupBy("host")
-          .getRawMany()
-      ).map(async ({ host }) => {
-        let isPublic = false
-        try {
-          const resp = await axios.get(`http://${host}`)
-          if (resp && resp.status) {
-            isPublic = true
-          }
-        } catch (err) {
-          // pass
-        }
-        try {
-          const res = await getEntityManager({}, queryRunner).insert(Hosts, [
-            { host, isPublic },
-          ])
-        } catch (err) {
-          // pass
-        }
-      }),
+      `CREATE TABLE IF NOT EXISTS "hosts" ("uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "host" text NOT NULL,"isPublic" bool DEFAULT false, CONSTRAINT "PK_hosts" PRIMARY KEY ("uuid"), CONSTRAINT "unique_host_per_org" UNIQUE ("host"))`,
     )
   }
 

--- a/backend/src/models/hosts.ts
+++ b/backend/src/models/hosts.ts
@@ -1,7 +1,8 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm"
+import { Column, Entity, PrimaryGeneratedColumn, Unique } from "typeorm"
 import MetloBaseEntity from "./metlo-base-entity"
 
 @Entity()
+@Unique("unique_host_per_org", ["host"])
 export class Hosts extends MetloBaseEntity {
   @PrimaryGeneratedColumn("uuid")
   uuid: string

--- a/backend/src/models/hosts.ts
+++ b/backend/src/models/hosts.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm"
+import MetloBaseEntity from "./metlo-base-entity"
+
+@Entity()
+export class Hosts extends MetloBaseEntity {
+  @PrimaryGeneratedColumn("uuid")
+  uuid: string
+
+  @Column()
+  host: string
+
+  @Column({ default: false })
+  isPublic: boolean
+}

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -14,6 +14,7 @@ import { AggregateTraceDataHourly } from "./aggregate-trace-data-hourly"
 import { Attack } from "./attack"
 import { Webhook } from "./webhook"
 import { TestingConfig } from "./testing-config"
+import { Hosts } from "./hosts"
 
 export type DatabaseModel =
   | ApiEndpoint
@@ -32,6 +33,7 @@ export type DatabaseModel =
   | Attack
   | Webhook
   | TestingConfig
+  | Hosts
 
 export {
   ApiEndpoint,
@@ -50,4 +52,5 @@ export {
   Attack,
   Webhook,
   TestingConfig,
+  Hosts,
 }

--- a/backend/src/services/database/utils.ts
+++ b/backend/src/services/database/utils.ts
@@ -30,6 +30,25 @@ export const getQB = (ctx: MetloContext, queryRunner: QueryRunner) => {
   return qb
 }
 
+export function getLeftJoinQB<Entity extends ObjectLiteral>(
+  ctx: MetloContext,
+  queryRunner: QueryRunner,
+  selectCols: string[],
+  fromEnt: EntityTarget<Entity>,
+  fromAlias: string,
+  leftJoinEnt: Function | string,
+  leftJoinAlias: string,
+  leftJoinCondition?: string,
+) {
+  let qb = queryRunner.manager
+    .createQueryBuilder()
+    .select(selectCols)
+    .from(fromEnt, fromAlias)
+    .leftJoin(leftJoinEnt, leftJoinAlias, leftJoinCondition)
+  qb.where = qb.andWhere
+  return qb
+}
+
 export function insertValueBuilder<Entity extends ObjectLiteral>(
   ctx: MetloContext,
   queryRunner: QueryRunner,

--- a/backend/src/services/get-endpoints/index.ts
+++ b/backend/src/services/get-endpoints/index.ts
@@ -10,6 +10,7 @@ import {
   DataField,
   OpenApiSpec,
   Attack,
+  Hosts,
 } from "models"
 import {
   ApiEndpoint as ApiEndpointResponse,
@@ -39,6 +40,7 @@ import { retryTypeormTransaction } from "utils/db"
 import { RedisClient } from "utils/redis"
 import { getGlobalFullTraceCaptureCached } from "services/metlo-config"
 import Error400BadRequest from "errors/error-400-bad-request"
+import { groupBy, isArray, mergeWith } from "lodash"
 
 export class GetEndpointsService {
   static async deleteEndpoint(
@@ -536,9 +538,12 @@ export class GetEndpointsService {
         qb = qb.andWhere("host ILIKE :searchQuery", {
           searchQuery: `%${getHostsParams.searchQuery}%`,
         })
-        totalHostsQb = totalHostsQb.andWhere("host ILIKE :searchQuery", {
-          searchQuery: `%${getHostsParams.searchQuery}%`,
-        })
+        totalHostsQb = totalHostsQb.andWhere(
+          "endpoint.host ILIKE :searchQuery",
+          {
+            searchQuery: `%${getHostsParams.searchQuery}%`,
+          },
+        )
       }
 
       qb = qb
@@ -548,8 +553,17 @@ export class GetEndpointsService {
 
       const hostsResp = await qb.getRawMany()
       const totalHosts = await totalHostsQb.getRawOne()
+      let res = hostsResp
+      try {
+        let hosts = await getEntityManager(ctx, queryRunner).find(Hosts)
+        res = hostsResp.map(resp => ({
+          ...resp,
+          isPublic:
+            hosts.find(host => host.host === resp.host)?.isPublic || false,
+        }))
+      } catch (err) {}
 
-      return [hostsResp, totalHosts?.numHosts ?? 0]
+      return [res, totalHosts?.numHosts ?? 0]
     } catch (err) {
       throw new Error500InternalServer(err)
     } finally {

--- a/backend/src/services/get-endpoints/index.ts
+++ b/backend/src/services/get-endpoints/index.ts
@@ -537,8 +537,8 @@ export class GetEndpointsService {
         qb = qb.andWhere("host ILIKE :searchQuery", {
           searchQuery: `%${getHostsParams.searchQuery}%`,
         })
-        totalHostsQb = totalHostsQb.andWhere("endpoint.host ILIKE :searchQuery", {
-            searchQuery: `%${getHostsParams.searchQuery}%`,
+        totalHostsQb = totalHostsQb.andWhere("host ILIKE :searchQuery", {
+          searchQuery: `%${getHostsParams.searchQuery}%`,
         })
       }
 

--- a/backend/src/services/get-endpoints/queries.ts
+++ b/backend/src/services/get-endpoints/queries.ts
@@ -1,4 +1,4 @@
-import { ApiEndpoint, DataField } from "models"
+import { ApiEndpoint, DataField, Hosts } from "models"
 import { MetloContext } from "types"
 
 export const getEndpointsQuery = (
@@ -9,7 +9,8 @@ export const getEndpointsQuery = (
 ) => `
   SELECT
     endpoint.*,
-    data_field."dataClasses"
+    data_field."dataClasses",
+    COALESCE("hosts"."isPublic", false) as "isPublic"
   FROM
     ${ApiEndpoint.getTableName(ctx)} endpoint
     LEFT JOIN LATERAL (
@@ -22,6 +23,8 @@ export const getEndpointsQuery = (
         data_field."apiEndpointUuid" = endpoint.uuid
         AND cardinality(data_field."dataClasses") > 0
     ) data_field ON true
+    LEFT JOIN ${Hosts.getTableName(ctx)} hosts
+      on "hosts"."host" = "endpoint"."host"
   ${whereFilter}
   ORDER BY
     endpoint."riskScore" DESC,
@@ -48,5 +51,7 @@ export const getEndpointsCountQuery = (
         data_field."apiEndpointUuid" = endpoint.uuid
         AND cardinality(data_field."dataClasses") > 0
     ) data_field ON true
+    LEFT JOIN ${Hosts.getTableName(ctx)} hosts
+      on "hosts"."host" = "endpoint"."host"
   ${whereFilter}
 `

--- a/backend/src/services/jobs/constants.ts
+++ b/backend/src/services/jobs/constants.ts
@@ -47,4 +47,9 @@ export const JOB_NAME_MAP: Record<JobName, JobMap> = {
     end: "Finished Detecting Sensitive Data",
     threshold: 1000 * 60 * 14,
   },
+  [JobName.DETECT_PRIVATE_IP]: {
+    start: "Detecting Private Hosts...",
+    end: "Finished updating private hosts list ",
+    threshold: 1000 * 60 * 14,
+  },
 }

--- a/backend/src/services/jobs/constants.ts
+++ b/backend/src/services/jobs/constants.ts
@@ -47,7 +47,7 @@ export const JOB_NAME_MAP: Record<JobName, JobMap> = {
     end: "Finished Detecting Sensitive Data",
     threshold: 1000 * 60 * 14,
   },
-  [JobName.DETECT_PRIVATE_IP]: {
+  [JobName.DETECT_PRIVATE_HOSTS]: {
     start: "Detecting Private Hosts...",
     end: "Finished updating private hosts list ",
     threshold: 1000 * 60 * 14,

--- a/backend/src/services/jobs/constants.ts
+++ b/backend/src/services/jobs/constants.ts
@@ -50,6 +50,6 @@ export const JOB_NAME_MAP: Record<JobName, JobMap> = {
   [JobName.DETECT_PRIVATE_HOSTS]: {
     start: "Detecting Private Hosts...",
     end: "Finished updating private hosts list ",
-    threshold: 1000 * 60 * 14,
+    threshold: 1000 * 60 * 55,
   },
 }

--- a/backend/src/services/jobs/detect-private-hosts.ts
+++ b/backend/src/services/jobs/detect-private-hosts.ts
@@ -40,7 +40,11 @@ export const detectPrivateHosts = async (
             .orUpdate(["isPublic", "host"], ["host"], {})
             .execute()
         } catch (err) {
-          mlog.withErr(err).error("Could not write back to Hosts table for public/private hosts")
+          mlog
+            .withErr(err)
+            .error(
+              "Could not write back to Hosts table for public/private hosts",
+            )
         } finally {
           await qr.release()
         }
@@ -48,7 +52,7 @@ export const detectPrivateHosts = async (
     )
   } catch (err) {
     mlog.withErr(err).log("Caught an error write private/public hosts")
-    throw err
+    return false
   } finally {
     await queryRunner.release()
   }

--- a/backend/src/services/jobs/detect-private-hosts.ts
+++ b/backend/src/services/jobs/detect-private-hosts.ts
@@ -1,11 +1,6 @@
 import { AppDataSource } from "data-source"
-import { Hosts, ApiKey, ApiEndpoint } from "models"
-import {
-  createQB,
-  getEntityManager,
-  getQB,
-  getRepoQB,
-} from "services/database/utils"
+import { Hosts, ApiEndpoint } from "models"
+import { createQB, getQB } from "services/database/utils"
 import { MetloContext } from "types"
 import axios from "axios"
 import mlog from "logger"
@@ -45,14 +40,14 @@ export const detectPrivateHosts = async (
             .orUpdate(["isPublic", "host"], ["host"], {})
             .execute()
         } catch (err) {
-          console.log(err)
+          mlog.withErr(err).error("Could not write back to Hosts table for public/private hosts")
         } finally {
           await qr.release()
         }
       }),
     )
   } catch (err) {
-    mlog.withErr(err).log("Caught an error detecting private/public IPs")
+    mlog.withErr(err).log("Caught an error write private/public hosts")
     throw err
   } finally {
     await queryRunner.release()

--- a/backend/src/services/jobs/detect-private-hosts.ts
+++ b/backend/src/services/jobs/detect-private-hosts.ts
@@ -24,7 +24,7 @@ export const detectPrivateHosts = async (
           await qr.connect()
           let isPublic = false
           try {
-            const resp = await axios.get(`http://${host}`)
+            const resp = await axios.get(`http://${host}`, { timeout: 5 })
             if (resp && resp.status) {
               isPublic = true
             }

--- a/backend/src/services/jobs/detect-private-ip.ts
+++ b/backend/src/services/jobs/detect-private-ip.ts
@@ -34,7 +34,6 @@ export const detectPrivateHosts = async (
               isPublic = true
             }
           } catch (err) {
-            console.log(err.message)
             if (err.code == "ERR_TLS_CERT_ALTNAME_INVALID") {
               isPublic = true
             }

--- a/backend/src/services/jobs/detect-private-ip.ts
+++ b/backend/src/services/jobs/detect-private-ip.ts
@@ -1,0 +1,40 @@
+import { AppDataSource } from "data-source"
+import { Hosts, ApiKey } from "models"
+import { getEntityManager, getQB, getRepoQB } from "services/database/utils"
+import { MetloContext } from "types"
+import axios from "axios"
+
+export const detectPrivateHosts = async (
+  ctx: MetloContext,
+): Promise<boolean> => {
+  const hosts = await Hosts.find()
+  await Promise.all(
+    hosts.map(async host => {
+      const queryrunner = AppDataSource.createQueryRunner()
+      try {
+        await queryrunner.connect()
+        let isPublic = false
+        try {
+          const resp = await axios.get(`http://${host.host}`)
+          if (resp && resp.status) {
+            isPublic = true
+          }
+        } catch (err) {
+          console.log(err)
+          // pass
+        }
+        await getEntityManager(ctx, queryrunner).update(
+          Hosts,
+          { uuid: host.uuid },
+          { isPublic },
+        )
+      } catch (err) {
+        console.log(err)
+      } finally {
+        await queryrunner.release()
+      }
+    }),
+  )
+
+  return true
+}

--- a/backend/src/services/jobs/detect-private-ip.ts
+++ b/backend/src/services/jobs/detect-private-ip.ts
@@ -21,7 +21,6 @@ export const detectPrivateHosts = async (
           }
         } catch (err) {
           console.log(err)
-          // pass
         }
         await getEntityManager(ctx, queryrunner).update(
           Hosts,

--- a/backend/src/services/jobs/detect-private-ip.ts
+++ b/backend/src/services/jobs/detect-private-ip.ts
@@ -1,39 +1,66 @@
 import { AppDataSource } from "data-source"
-import { Hosts, ApiKey } from "models"
-import { getEntityManager, getQB, getRepoQB } from "services/database/utils"
+import { Hosts, ApiKey, ApiEndpoint } from "models"
+import {
+  createQB,
+  getEntityManager,
+  getQB,
+  getRepoQB,
+} from "services/database/utils"
 import { MetloContext } from "types"
 import axios from "axios"
+import mlog from "logger"
 
 export const detectPrivateHosts = async (
   ctx: MetloContext,
 ): Promise<boolean> => {
-  const hosts = await Hosts.find()
-  await Promise.all(
-    hosts.map(async host => {
-      const queryrunner = AppDataSource.createQueryRunner()
-      try {
-        await queryrunner.connect()
-        let isPublic = false
+  let queryRunner = AppDataSource.createQueryRunner()
+  try {
+    await queryRunner.connect()
+    const hosts = await getQB(ctx, queryRunner)
+      .select(["host"])
+      .from(ApiEndpoint, "endpoint")
+      .distinct(true)
+      .groupBy("host")
+      .getRawMany()
+    await Promise.all(
+      hosts.map(async ({ host }) => {
+        const qr = AppDataSource.createQueryRunner()
         try {
-          const resp = await axios.get(`http://${host.host}`)
-          if (resp && resp.status) {
-            isPublic = true
+          await qr.connect()
+          let isPublic = false
+          try {
+            const resp = await axios.get(`http://${host}`)
+            if (resp && resp.status) {
+              isPublic = true
+            }
+          } catch (err) {
+            console.log(err.message)
+            if (err.code == "ERR_TLS_CERT_ALTNAME_INVALID") {
+              isPublic = true
+            }
           }
+          await createQB(ctx)
+            .insert()
+            .into(Hosts, ["isPublic", "host"])
+            .values([{ isPublic, host }])
+            .orUpdate(["isPublic", "host"], ["host"], {})
+            .execute()
+          // await getEntityManager(ctx, qr)
+          //   .insert(Hosts, { uuid: host.uuid }, { isPublic })
+          //   .update()
         } catch (err) {
           console.log(err)
+        } finally {
+          await qr.release()
         }
-        await getEntityManager(ctx, queryrunner).update(
-          Hosts,
-          { uuid: host.uuid },
-          { isPublic },
-        )
-      } catch (err) {
-        console.log(err)
-      } finally {
-        await queryrunner.release()
-      }
-    }),
-  )
+      }),
+    )
+  } catch (err) {
+    mlog.withErr(err).log("Caught an error detecting private/public IPs")
+    throw err
+  } finally {
+    await queryRunner.release()
+  }
 
   return true
 }

--- a/backend/src/services/jobs/detect-private-ip.ts
+++ b/backend/src/services/jobs/detect-private-ip.ts
@@ -45,9 +45,6 @@ export const detectPrivateHosts = async (
             .values([{ isPublic, host }])
             .orUpdate(["isPublic", "host"], ["host"], {})
             .execute()
-          // await getEntityManager(ctx, qr)
-          //   .insert(Hosts, { uuid: host.uuid }, { isPublic })
-          //   .update()
         } catch (err) {
           console.log(err)
         } finally {

--- a/backend/src/services/jobs/processor.ts
+++ b/backend/src/services/jobs/processor.ts
@@ -12,7 +12,7 @@ import { JobName } from "./types"
 import { wrapProcessor } from "./wrap-processor"
 import { updateEndpointIps } from "analyze/jobs"
 import { logAggregatedStats } from "services/logging"
-import { detectPrivateHosts } from "./detect-private-ip"
+import { detectPrivateHosts } from "./detect-private-hosts"
 
 const processor = async (job: Job, done) => {
   const ctx = {}

--- a/backend/src/services/jobs/processor.ts
+++ b/backend/src/services/jobs/processor.ts
@@ -53,7 +53,7 @@ const processor = async (job: Job, done) => {
     case JobName.DETECT_SENSITIVE_DATA:
       success = await detectSensitiveData(ctx)
       break
-    case JobName.DETECT_PRIVATE_IP:
+    case JobName.DETECT_PRIVATE_HOSTS:
       success = await detectPrivateHosts(ctx)
       break
     default:

--- a/backend/src/services/jobs/processor.ts
+++ b/backend/src/services/jobs/processor.ts
@@ -12,6 +12,7 @@ import { JobName } from "./types"
 import { wrapProcessor } from "./wrap-processor"
 import { updateEndpointIps } from "analyze/jobs"
 import { logAggregatedStats } from "services/logging"
+import { detectPrivateHosts } from "./detect-private-ip"
 
 const processor = async (job: Job, done) => {
   const ctx = {}
@@ -51,6 +52,9 @@ const processor = async (job: Job, done) => {
       break
     case JobName.DETECT_SENSITIVE_DATA:
       success = await detectSensitiveData(ctx)
+      break
+    case JobName.DETECT_PRIVATE_IP:
+      success = await detectPrivateHosts(ctx)
       break
     default:
       break

--- a/backend/src/services/jobs/types.ts
+++ b/backend/src/services/jobs/types.ts
@@ -37,4 +37,5 @@ export enum JobName {
   LOG_AGGREGATED_STATS = "log_aggregated_stats",
   FIX_ENDPOINTS = "fix_endpoints",
   DETECT_SENSITIVE_DATA = "detect_sensitive_data",
+  DETECT_PRIVATE_IP = "detect_private_ip",
 }

--- a/backend/src/services/jobs/types.ts
+++ b/backend/src/services/jobs/types.ts
@@ -37,5 +37,5 @@ export enum JobName {
   LOG_AGGREGATED_STATS = "log_aggregated_stats",
   FIX_ENDPOINTS = "fix_endpoints",
   DETECT_SENSITIVE_DATA = "detect_sensitive_data",
-  DETECT_PRIVATE_IP = "detect_private_ip",
+  DETECT_PRIVATE_HOSTS = "detect_private_host",
 }

--- a/common/src/api/endpoint.ts
+++ b/common/src/api/endpoint.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import {
   DataSection,
   HostSortOptions,
+  HostType,
   RestMethod,
   RiskScore,
   SortOrder,
@@ -15,6 +16,7 @@ export const GetEndpointParamsSchema = z.object({
   dataClasses: z.string().array().optional(),
   searchQuery: z.string().optional(),
   isAuthenticated: z.string().optional(),
+  hostType: z.nativeEnum(HostType).optional().default(HostType.ANY),
   offset: z
     .union([z.number(), z.string().regex(/^\d+$/).transform(Number)])
     .optional(),
@@ -43,6 +45,7 @@ export type UpdateDataFieldClassesParams = z.infer<
 
 export const GetHostParamsSchema = z.object({
   searchQuery: z.string().optional(),
+  hostType: z.nativeEnum(HostType).optional().default(HostType.ANY),
   offset: z
     .union([z.number(), z.string().regex(/^\d+$/).transform(Number)])
     .optional(),

--- a/common/src/enums.ts
+++ b/common/src/enums.ts
@@ -49,6 +49,12 @@ export enum RiskScore {
   HIGH = "high",
 }
 
+export enum HostType {
+  PUBLIC = "Public",
+  PRIVATE = "Private",
+  ANY = "Any",
+}
+
 export enum AlertType {
   NEW_ENDPOINT = "New Endpoint Detected",
   PII_DATA_DETECTED = "PII Data Detected",

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -186,6 +186,7 @@ export interface ApiEndpoint {
   isAuthenticatedUserSet: boolean
   fullTraceCaptureEnabled: boolean
   isGraphQl: boolean
+  isPublic?: boolean
 }
 
 export interface ApiEndpointDetailed extends ApiEndpoint {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -201,6 +201,7 @@ export interface ApiEndpointDetailed extends ApiEndpoint {
 export interface HostResponse {
   host: string
   numEndpoints: number
+  isPublic: boolean
 }
 
 export interface OpenApiSpec {

--- a/frontend/src/components/EndpointList/Filters.tsx
+++ b/frontend/src/components/EndpointList/Filters.tsx
@@ -288,7 +288,7 @@ const EndpointFilters: React.FC<EndpointFilterProps> = React.memo(
             </GridItem>
             <GridItem colSpan={2}>
               <Box zIndex="1001" w={{ base: "full", lg: "xs" }}>
-                <FilterHeader title="Sensitive Data Class" />
+                <FilterHeader title="Host Visibility" />
                 <Select
                   className="chakra-react-select"
                   options={[

--- a/frontend/src/components/EndpointList/Filters.tsx
+++ b/frontend/src/components/EndpointList/Filters.tsx
@@ -15,7 +15,7 @@ import {
 import { Select } from "chakra-react-select"
 import { BsSearch } from "icons/bs/BsSearch"
 import { GetEndpointParams } from "@common/api/endpoint"
-import { RestMethod, RiskScore } from "@common/enums"
+import { HostType, RestMethod, RiskScore } from "@common/enums"
 import debounce from "lodash/debounce"
 
 interface EndpointFilterProps {
@@ -283,6 +283,30 @@ const EndpointFilters: React.FC<EndpointFilterProps> = React.memo(
                       offset: 0,
                     })
                   }
+                />
+              </Box>
+            </GridItem>
+            <GridItem colSpan={2}>
+              <Box zIndex="1001" w={{ base: "full", lg: "xs" }}>
+                <FilterHeader title="Sensitive Data Class" />
+                <Select
+                  className="chakra-react-select"
+                  options={[
+                    { label: HostType.ANY, value: HostType.ANY },
+                    { label: HostType.PUBLIC, value: HostType.PUBLIC },
+                    { label: HostType.PRIVATE, value: HostType.PRIVATE },
+                  ]}
+                  size="sm"
+                  value={{
+                    label: params.hostType || HostType.ANY,
+                    value: params.hostType || HostType.ANY,
+                  }}
+                  onChange={e => {
+                    setParams({
+                      hostType: e.label || HostType.ANY,
+                    })
+                  }}
+                  placeholder="Host public visibility..."
                 />
               </Box>
             </GridItem>

--- a/frontend/src/components/EndpointList/List.tsx
+++ b/frontend/src/components/EndpointList/List.tsx
@@ -220,9 +220,12 @@ const List: React.FC<EndpointTablesProps> = React.memo(
         sortable: false,
         selector: (row: ApiEndpoint) => row.host || "",
         cell: (row: ApiEndpoint) => (
-          <Text pointerEvents="none" fontWeight="normal">
-            {row.host}
-          </Text>
+          <HStack spacing={1}>
+            <Text pointerEvents="none" fontWeight="normal">
+              {row.host}
+            </Text>
+            <Badge>{row.isPublic ? "Public" : "Private"}</Badge>
+          </HStack>
         ),
         id: "host",
         grow: 2,

--- a/frontend/src/components/EndpointList/List.tsx
+++ b/frontend/src/components/EndpointList/List.tsx
@@ -4,7 +4,7 @@ import {
   Box,
   Text,
   useColorMode,
-  HStack,
+  VStack,
   Tag,
   Tooltip,
 } from "@chakra-ui/react"
@@ -220,12 +220,12 @@ const List: React.FC<EndpointTablesProps> = React.memo(
         sortable: false,
         selector: (row: ApiEndpoint) => row.host || "",
         cell: (row: ApiEndpoint) => (
-          <HStack spacing={1}>
+          <VStack spacing={1} alignItems="flex-start">
             <Text pointerEvents="none" fontWeight="normal">
               {row.host}
             </Text>
             <Badge>{row.isPublic ? "Public" : "Private"}</Badge>
-          </HStack>
+          </VStack>
         ),
         id: "host",
         grow: 2,
@@ -247,7 +247,7 @@ const List: React.FC<EndpointTablesProps> = React.memo(
           </Tooltip>
         ),
         id: "firstDetected",
-        grow: 1.5,
+        grow: 1.0,
         right: true,
       },
       {
@@ -267,7 +267,7 @@ const List: React.FC<EndpointTablesProps> = React.memo(
         ),
         id: "lastActive",
         right: true,
-        grow: 1.5,
+        grow: 1.0,
       },
     ]
 

--- a/frontend/src/components/HostList/Filters.tsx
+++ b/frontend/src/components/HostList/Filters.tsx
@@ -13,6 +13,8 @@ import {
   AlertDialogHeader,
   AlertDialogBody,
   AlertDialogFooter,
+  HStack,
+  Box,
 } from "@chakra-ui/react"
 import { BsSearch } from "icons/bs/BsSearch"
 import debounce from "lodash/debounce"
@@ -20,6 +22,8 @@ import { GetHostParams } from "@common/api/endpoint"
 import { deleteHosts } from "api/endpoints"
 import { makeToast } from "utils"
 import { formatMetloAPIErr, MetloAPIErr } from "api/utils"
+import { Select } from "chakra-react-select"
+import { HostType } from "@common/enums"
 
 interface HostFilterProps {
   params: GetHostParams
@@ -30,10 +34,10 @@ interface HostFilterProps {
 
 const HostFilters: React.FC<HostFilterProps> = React.memo(
   ({ params, setParams, selectedHosts, setSelectedHosts }) => {
-    const setSearchQuery = (val: string) => {
+    const setSearchQuery = (searchQuery: string) => {
       setParams(old => ({
         ...old,
-        searchQuery: val,
+        searchQuery,
         offset: 0,
       }))
     }
@@ -53,7 +57,7 @@ const HostFilters: React.FC<HostFilterProps> = React.memo(
       return () => {
         debounceSearch.cancel()
       }
-    }, [params.searchQuery])
+    }, [params.searchQuery, params.hostType])
 
     const handleDeleteHostsClick = async () => {
       try {
@@ -90,23 +94,48 @@ const HostFilters: React.FC<HostFilterProps> = React.memo(
         w="full"
         justifyContent="space-between"
       >
-        <InputGroup>
-          <InputLeftElement pointerEvents="none">
-            <BsSearch />
-          </InputLeftElement>
-          <Input
-            spellCheck={false}
-            value={tmpQuery}
-            onChange={e => {
-              debounceSearch(e.target.value)
-              setTmpQuery(e.target.value)
-            }}
-            w={{ base: "full", lg: "xs" }}
-            type="text"
-            placeholder="Search for host..."
-            bg="white"
-          />
-        </InputGroup>
+        <HStack spacing={4}>
+          <Box>
+            <InputGroup>
+              <InputLeftElement pointerEvents="none">
+                <BsSearch />
+              </InputLeftElement>
+              <Input
+                spellCheck={false}
+                value={tmpQuery}
+                onChange={e => {
+                  debounceSearch(e.target.value)
+                  setTmpQuery(e.target.value)
+                }}
+                w={{ base: "full", lg: "xs" }}
+                type="text"
+                placeholder="Search for host..."
+                bg="white"
+              />
+            </InputGroup>
+          </Box>
+          <Box w={{ base: "full", lg: "xs" }}>
+            <Select
+              className="chakra-react-select"
+              options={[
+                { label: HostType.ANY, value: HostType.ANY },
+                { label: HostType.PUBLIC, value: HostType.PUBLIC },
+                { label: HostType.PRIVATE, value: HostType.PRIVATE },
+              ]}
+              value={{
+                label: params.hostType || HostType.ANY,
+                value: params.hostType || HostType.ANY,
+              }}
+              onChange={e => {
+                setParams(old => ({
+                  ...old,
+                  hostType: e.label || HostType.ANY,
+                }))
+              }}
+              placeholder="Host public visibility..."
+            />
+          </Box>
+        </HStack>
         <Button
           variant="delete"
           isDisabled={selectedHosts.length === 0}

--- a/frontend/src/components/HostList/List.tsx
+++ b/frontend/src/components/HostList/List.tsx
@@ -145,11 +145,9 @@ const List: React.FC<HostTableProps> = React.memo(
       {
         name: "Endpoints",
         sortable: true,
-        selector: (row: HostResponse) => row.host || "",
+        selector: (row: HostResponse) => row.numEndpoints || "",
         cell: (row: HostResponse) => (
-          <Text color="gray.900" key={row.host}>
-            {row.numEndpoints}
-          </Text>
+          <Text color="gray.900">{row.numEndpoints}</Text>
         ),
         id: "numEndpoints",
         right: true,
@@ -158,7 +156,7 @@ const List: React.FC<HostTableProps> = React.memo(
       {
         name: "Is Public Host",
         sortable: false,
-        selector: (row: HostResponse) => row.host || "",
+        selector: (row: HostResponse) => row.isPublic || "",
         cell: (row: HostResponse) => (
           <Text
             color={row.isPublic ? "green.500" : "red.500"}
@@ -174,7 +172,6 @@ const List: React.FC<HostTableProps> = React.memo(
       {
         name: "",
         sortable: false,
-        selector: (row: HostResponse) => row.host || "",
         cell: (row: HostResponse) => (
           <Button
             size="xs"

--- a/frontend/src/components/HostList/List.tsx
+++ b/frontend/src/components/HostList/List.tsx
@@ -6,6 +6,7 @@ import {
   Wrap,
   WrapItem,
   Button,
+  Badge,
 } from "@chakra-ui/react"
 import { useRouter } from "next/router"
 import EmptyView from "components/utils/EmptyView"
@@ -56,6 +57,12 @@ const TableLoader: React.FC<TableLoaderProps> = ({
     {
       name: "Endpoints",
       id: "numEndpoints",
+      grow: 4,
+    },
+    {
+      name: "Is Public Host",
+      id: "isPublic",
+      right: true,
       grow: 4,
     },
     {
@@ -158,12 +165,9 @@ const List: React.FC<HostTableProps> = React.memo(
         sortable: false,
         selector: (row: HostResponse) => row.isPublic || "",
         cell: (row: HostResponse) => (
-          <Text
-            color={row.isPublic ? "green.500" : "red.500"}
-            fontWeight={"semibold"}
-          >
+          <Badge fontWeight={"semibold"}>
             {row.isPublic ? "Public" : "Private"}
-          </Text>
+          </Badge>
         ),
         id: "isPublic",
         right: true,

--- a/frontend/src/components/HostList/List.tsx
+++ b/frontend/src/components/HostList/List.tsx
@@ -145,17 +145,36 @@ const List: React.FC<HostTableProps> = React.memo(
       {
         name: "Endpoints",
         sortable: true,
-        selector: (row: HostResponse) => row.numEndpoints,
+        selector: (row: HostResponse) => row.host || "",
         cell: (row: HostResponse) => (
-          <Text color="gray.900">{row.numEndpoints}</Text>
+          <Text color="gray.900" key={row.host}>
+            {row.numEndpoints}
+          </Text>
         ),
         id: "numEndpoints",
         right: true,
         grow: 4,
       },
       {
+        name: "Is Public Host",
+        sortable: false,
+        selector: (row: HostResponse) => row.host || "",
+        cell: (row: HostResponse) => (
+          <Text
+            color={row.isPublic ? "green.500" : "red.500"}
+            fontWeight={"semibold"}
+          >
+            {row.isPublic ? "Public" : "Private"}
+          </Text>
+        ),
+        id: "isPublic",
+        right: true,
+        grow: 4,
+      },
+      {
         name: "",
         sortable: false,
+        selector: (row: HostResponse) => row.host || "",
         cell: (row: HostResponse) => (
           <Button
             size="xs"
@@ -180,6 +199,7 @@ const List: React.FC<HostTableProps> = React.memo(
 
     const getTable = () => (
       <DataTable
+        keyField="host"
         style={rowStyles}
         paginationComponentOptions={{ noRowsPerPage: true }}
         paginationTotalRows={totalCount}

--- a/frontend/src/pages/endpoints.tsx
+++ b/frontend/src/pages/endpoints.tsx
@@ -19,7 +19,7 @@ import { useState, useRef } from "react"
 import { GetServerSideProps } from "next"
 import { ApiEndpoint, DataClass } from "@common/types"
 import { GetEndpointParams } from "@common/api/endpoint"
-import { RestMethod, RiskScore } from "@common/enums"
+import { HostType, RestMethod, RiskScore } from "@common/enums"
 import EndpointList from "components/EndpointList"
 import { PageWrapper } from "components/PageWrapper"
 import { ContentContainer } from "components/utils/ContentContainer"
@@ -184,6 +184,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     dataClasses: ((context.query.dataClasses as string) || "")
       .split(",")
       .filter(e => dataClasses.find(({ className }) => className == e)),
+    hostType: (context.query.hostType as HostType) || HostType.ANY,
     offset: parseInt((context.query.offset as string) ?? "0"),
     searchQuery: (context.query.searchQuery as string) ?? "",
     isAuthenticated: (context.query.isAuthenticated as string) ?? "",

--- a/frontend/src/pages/hosts.tsx
+++ b/frontend/src/pages/hosts.tsx
@@ -12,7 +12,7 @@ import HostList from "components/HostList"
 import HostGraphComponent from "components/HostsGraph"
 import { useRouter } from "next/router"
 import { HostsTab } from "enums"
-import { HostSortOptions, SortOrder } from "@common/enums"
+import { HostSortOptions, HostType, SortOrder } from "@common/enums"
 
 const Hosts = ({ hosts, hostsGraph, totalCount, params }) => {
   const router = useRouter()
@@ -136,6 +136,7 @@ const Hosts = ({ hosts, hostsGraph, totalCount, params }) => {
 export const getServerSideProps: GetServerSideProps = async context => {
   const params: GetHostParams = {
     searchQuery: (context.query.searchQuery as string) ?? "",
+    hostType: (context.query.hostType as HostType) ?? HostType.ANY,
     offset: parseInt((context.query.offset as string) ?? "0"),
     limit: HOST_PAGE_LIMIT,
     sortBy: ((context.query.sortBy as string) ||


### PR DESCRIPTION
## Endpoint page:
<img width="1792" alt="Screenshot 2023-02-23 at 11 43 04 PM" src="https://user-images.githubusercontent.com/32181677/220994890-0a964f8d-4561-471e-bdd1-ad5c39b5b018.png">
Separate column for public/private host wasn't added since it was already very crowded. Instead, it was included along with the host name itself, so it's easily understandable and keeps current alignments. Host public/private filtering is added under advanced filters.

## Hosts page:
<img width="1792" alt="Screenshot 2023-02-23 at 11 45 18 PM" src="https://user-images.githubusercontent.com/32181677/220995132-3655ba78-34c3-444a-bf19-2360fae3a444.png">

## Filtering example (on hosts page):
<img width="1792" alt="Screenshot 2023-02-23 at 11 47 46 PM" src="https://user-images.githubusercontent.com/32181677/220995642-93a4f099-34a2-419c-8696-fde131336d03.png">

