### PR TITLE
ingestors/golang: fix `GetKeyValuePairValue` to return correct value

### DIFF
--- a/ingestors/golang/metlo/block.go
+++ b/ingestors/golang/metlo/block.go
@@ -125,7 +125,7 @@ func GetXForwardedForFromValue(value *string) *string {
 
 func GetSourceIp(reqHeaders []NV, traceMeta TraceMeta) *string {
 	for _, header := range reqHeaders {
-		if strings.ToLower(header.Name) == "x-forwarded-for" {
+		if strings.EqualFold(header.Name, "x-forwarded-for") {
 			xForwardedValue := GetXForwardedForFromValue(&header.Value)
 			return xForwardedValue
 		}
@@ -160,8 +160,8 @@ func CheckStringCondition(condOperator *string, condValue *string, reqValue *str
 
 func GetKeyValuePairValue(key string, keyValuePairs []NV) *string {
 	for _, pair := range keyValuePairs {
-		if strings.ToLower(pair.Name) == key {
-			return &pair.Name
+		if strings.EqualFold(pair.Name, key) {
+			return &pair.Value
 		}
 	}
 	return nil
@@ -222,7 +222,7 @@ func CheckKeyValuePair(condOperator *string, condKey *string, condValue *string,
 		return false
 	}
 	for _, pair := range keyValuePairs {
-		if strings.ToLower(pair.Name) == strings.ToLower(*condKey) && CheckStringCondition(condOperator, condValue, &pair.Value) {
+		if strings.EqualFold(pair.Name, *condKey) && CheckStringCondition(condOperator, condValue, &pair.Value) {
 			return true
 		}
 	}
@@ -424,7 +424,7 @@ func HandleSessionIdentifier(authentication *Authentication, headers []NV, key *
 			return
 		}
 		headerKey := *authentication.HeaderKey
-		headerValuePtr := GetKeyValuePairValue(strings.ToLower(headerKey), headers)
+		headerValuePtr := GetKeyValuePairValue(headerKey, headers)
 		if headerValuePtr != nil {
 			key.WriteRune('_')
 			key.WriteString(*headerValuePtr)

--- a/ingestors/golang/metlo/block_test.go
+++ b/ingestors/golang/metlo/block_test.go
@@ -1,0 +1,48 @@
+package metlo
+
+import (
+	"testing"
+)
+
+func TestGetKeyValuePairValue(t *testing.T) {
+	keyValuePairs := []NV{
+		{Name: "key1", Value: "value1"},
+		{Name: "key2", Value: "value2"},
+		{Name: "key3", Value: "value3"},
+	}
+
+	t.Run("Existing key, case insensitive", func(t *testing.T) {
+		key := "KEY1"
+		expectedValue := "value1"
+
+		result := GetKeyValuePairValue(key, keyValuePairs)
+
+		if result == nil {
+			t.Errorf("Expected value for key '%s' to be '%s', but got nil", key, expectedValue)
+		} else if *result != expectedValue {
+			t.Errorf("Expected value for key '%s' to be '%s', but got '%s'", key, expectedValue, *result)
+		}
+	})
+
+	t.Run("Existing key, exact match", func(t *testing.T) {
+		key := "key3"
+		expectedValue := "value3"
+
+		result := GetKeyValuePairValue(key, keyValuePairs)
+
+		if result == nil {
+			t.Errorf("Expected value for key '%s' to be '%s', but got nil", key, expectedValue)
+		} else if *result != expectedValue {
+			t.Errorf("Expected value for key '%s' to be '%s', but got '%s'", key, expectedValue, *result)
+		}
+	})
+
+	t.Run("Non-existing key", func(t *testing.T) {
+		key := "nonexistent"
+		result := GetKeyValuePairValue(key, keyValuePairs)
+
+		if result != nil {
+			t.Errorf("Expected value for non-existing key '%s' to be nil, but got '%s'", key, *result)
+		}
+	})
+}


### PR DESCRIPTION
This commit fixes the bug where `GetKeyValuePairValue` is returning the "name" instead of "value".

This commit also replaces all `strings.ToLower` comparison with `strings.EqualFold`. Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
func BenchmarkToLowerSingle(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != "foobar" {
			b.Fail()
		}
	}
}

func BenchmarkToLowerMulti(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("FOOBAR", "foobar") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/metlo-labs/metlo/ingestors/golang/metlo cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToLowerSingle-16    	11675242	        91.26 ns/op	       8 B/op	       1 allocs/op
BenchmarkToLowerMulti-16     	10335708	       130.1 ns/op	       8 B/op	       1 allocs/op
BenchmarkEqualFold-16        	148562527	         7.983 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/metlo-labs/metlo/ingestors/golang/metlo	5.338s
```

/cc @NikhilShahi @AHarmlessPyro 